### PR TITLE
[concourse] Unzip fly.exe from fly-assets\fly-windows-amd64.zip

### DIFF
--- a/automatic/concourse/tools/chocolateyinstall.ps1
+++ b/automatic/concourse/tools/chocolateyinstall.ps1
@@ -8,4 +8,13 @@ $packageArgs = @{
 }
 
 Get-ChocolateyUnzip @packageArgs
+
+$installDir = Join-Path $packageArgs.destination $packageArgs.packageName
+
+$flyArgs = @{
+  File  = Join-Path $installDir "fly-assets\fly-windows-amd64.zip"
+  Destination = Join-Path $installDir "bin"
+}
+Get-ChocolateyUnzip @flyArgs
+
 Remove-Item -Path $packageArgs.file


### PR DESCRIPTION
The concourse client, fly.exe, is contained in fly-assets\fly-windows-amd64.zip in the main zip package.
This patch unzips fly.exe and puts it next to concourse.exe, allowing for shims to be generated for both.