### PR TITLE
(Wireguard) do not launch UI after install

### DIFF
--- a/automatic/wireguard/tools/chocolateyinstall.ps1
+++ b/automatic/wireguard/tools/chocolateyinstall.ps1
@@ -8,7 +8,7 @@ $packageArgs = @{
   file        = "$toolsDir\wireguard-x86-0.3.2.msi"
   file64      = "$toolsDir\wireguard-amd64-0.3.2.msi"
 
-  silentArgs  = "/qn /norestart /l*v `"$env:TEMP\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`""  
+  silentArgs  = "/qn /norestart /l*v `"$env:TEMP\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`" DO_NOT_LAUNCH=1"  
 }
 
 Install-ChocolateyInstallPackage @packageArgs


### PR DESCRIPTION
Hey, @chtof 

Should be fairly self-explanatory. Let me know if you have questions.

