### PR TITLE
Fix chocolateyinstall.ps1 to allow execution on Windows 7

### DIFF
--- a/automatic/spacedesk-server/tools/chocolateyinstall.ps1
+++ b/automatic/spacedesk-server/tools/chocolateyinstall.ps1
@@ -9,7 +9,9 @@ if ( [environment]::OSVersion.Version.Major -ge 10 )  {
   $checksum64_win10 = ''
   $url64            = $url64_win10
   $checksum64       = $checksum64_win10
-} elseif ( [environment]::OSVersion.Version.Major -ge 7 ) {
+} elseif ( ( [environment]::OSVersion.Version.Major -ge 7 ) -or
+           ( ( [environment]::OSVersion.Version.Major -eq 6 ) -and
+             ( [environment]::OSVersion.Version.Minor -eq 1 ) ) ) {
   $url32_win7_81      = 'https://spacedesk.net/downloads/spacedesk_driver_Win_8.1_32_v0973_BETA.msi'
   $checksum32_win7_81 = '48091a45254436440855b6e6c911690236cf2e90a466518bdab42f12cedd99f8'
   $url32              = $url32_win7_81


### PR DESCRIPTION
Spacedesk Homepage states its server component can be installed on Windows 7, but the spacedesk-server install script fails after checking the OS version, although its error message states compatibility with Windows 7. This patch corrects the script to work on Windows 7.