### PR TITLE
magicsplat-tcl-tk: enable ALLUSERS and set APPLICATIONFOLDERNAME to msi

### DIFF
--- a/automatic/magicsplat-tcl-tk/tools/chocolateyinstall.ps1
+++ b/automatic/magicsplat-tcl-tk/tools/chocolateyinstall.ps1
@@ -10,7 +10,7 @@ $packageArgs = @{
   file64        = "$toolsDir\tcl-8.6.11-installer-1.11.2-x64.msi"
   filetype64    = 'MSI'
 
-  silentArgs    = "/qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`""
+  silentArgs    = "ALLUSERS=1 APPLICATIONFOLDER=C:\Progra~1\Tcl /qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`""
 }
 
 Install-ChocolateyInstallPackage @packageArgs


### PR DESCRIPTION
Hello,

The default MSI install for this package puts it in a per-user directory under %USERPROFILE%. With chocolatey however, it should be installed for all users in a standard path that is accessible by all users (with admin permissions).
There are advanced options to enable the installation for all users and installdir in "C:\Program Files\Tcl". This PR enables these advanced options to the MSI installer.

Please check whether you want to incorporate it.

Thanks