### PR TITLE
Don't force TLS 1.1 on download of GNU Octave

### DIFF
--- a/automatic/evga-flow-control/tools/chocolateyinstall.ps1
+++ b/automatic/evga-flow-control/tools/chocolateyinstall.ps1
@@ -1,8 +1,6 @@
 ﻿$ErrorActionPreference = 'Stop';
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"  
 
-[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls11;
-
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
   unzipLocation = "$toolsDir"

--- a/automatic/octave.install/tools/chocolateyinstall.ps1
+++ b/automatic/octave.install/tools/chocolateyinstall.ps1
@@ -1,8 +1,6 @@
 ﻿$ErrorActionPreference = 'Stop';
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
-[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls11;
-
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
   destination   = "$toolsDir"


### PR DESCRIPTION
TLS 1.1 is no longer allowed on the GNU mirrors causing a failed connection when downloading GNU Octave.

After removing the line that forces TLS 1.1, chocolately was able to successfully download and install the package without issue.