### PR TITLE
Start "dnscrypt-proxy" service after upgrade

### DIFF
--- a/automatic/dnscrypt-proxy/tools/chocolateyinstall.ps1
+++ b/automatic/dnscrypt-proxy/tools/chocolateyinstall.ps1
@@ -14,4 +14,4 @@ Get-ChocolateyUnzip @packageArgs
 $serviceName = "dnscrypt-proxy"
 
 Write-Warning "Start the dnscrypt-proxy service..."
-Start-Service "$serviceName" -WarningAction SilentlyContinue
+Start-Service "$serviceName" -ErrorAction SilentlyContinue

--- a/automatic/dnscrypt-proxy/tools/chocolateyinstall.ps1
+++ b/automatic/dnscrypt-proxy/tools/chocolateyinstall.ps1
@@ -9,3 +9,9 @@ $packageArgs = @{
 }
 
 Get-ChocolateyUnzip @packageArgs
+
+# Start service after upgrade
+$serviceName = "dnscrypt-proxy"
+
+Write-Warning "Start the dnscrypt-proxy service..."
+Start-Service "$serviceName" -WarningAction SilentlyContinue


### PR DESCRIPTION
If the system DNS is set as "DNSCrypt", then it is absolutely necessary to start this service after upgrade, or Internet will be interrupted.