### PR TITLE
Fix broken source-han-code-jp

### DIFF
--- a/automatic/source-han-code-jp/tools/chocolateyinstall.ps1
+++ b/automatic/source-han-code-jp/tools/chocolateyinstall.ps1
@@ -10,8 +10,8 @@ $packageArgs = @{
     packageName    = $env:ChocolateyPackageName
     unzipLocation  = $tempPath    
 
-    url            = 'https://github.com/adobe-fonts/source-han-code-jp/archive/2.012.zip'
-    checksum       = '08a30d02c24dbd6f7974fdf23b8acb6b7768b0722ad1fea2b1b2fd037def964e'
+    url            = 'https://github.com/adobe-fonts/source-han-code-jp/archive/2.012R.zip'
+    checksum       = 'BEDC74973220F1CE4BB16E1FA64A46604C3164BF95B62FA48C8A046DD468D6EF'
     checksumType   = 'sha256'
 }
  

--- a/automatic/source-han-code-jp/update.ps1
+++ b/automatic/source-han-code-jp/update.ps1
@@ -2,10 +2,10 @@
 
 function global:au_GetLatest {
   $github_repository = "adobe-fonts/source-han-code-jp"
-  $releases = "https://github.com/" + $github_repository + "/releases/latest"
-  $regex   = "/(?<Version>[\d\.]+)[A-Z]*.zip$"
+  $releases = "https://github.com/" + $github_repository + "/releases"
+  $regex   = "/(?<Version>[\d\.]+)R.zip$"
 
-  $url = (Invoke-WebRequest -Uri $releases -UseBasicParsing).links | ? href -match $regex
+  $url = (Invoke-WebRequest -Uri $releases -UseBasicParsing).links | ? href -match $regex | Select-Object -First 1
   return @{
     Version = $matches.Version
     URL32 = "https://github.com" + $url.href
@@ -15,7 +15,7 @@ function global:au_GetLatest {
 function global:au_SearchReplace {
     @{
         "tools\chocolateyinstall.ps1" = @{
-			"(^(\s)*url\s*=\s*)('.*')" = "`$1'$($Latest.URL32)'"
+            "(^(\s)*url\s*=\s*)('.*')" = "`$1'$($Latest.URL32)'"
             "(^(\s)*checksum\s*=\s*)('.*')" = "`$1'$($Latest.Checksum32)'"
         }        
     }


### PR DESCRIPTION
The source-han-code-jp package is currently broken. These commits fix it.

Fixes:
- downloads a release archive instead of source code
- checksum
- update.ps1