### PR TITLE
Fix launchyqt package due to changes in release packaging

### DIFF
--- a/automatic/launchyqt/tools/chocolateyinstall.ps1
+++ b/automatic/launchyqt/tools/chocolateyinstall.ps1
@@ -5,13 +5,6 @@ $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
   destination   = "$toolsDir"
   file          = "$toolsDir\Launchy-3.1.2-win-x86.7z"
-  #file64        = "$toolsDir\Launchy-3.1.2-win-amd64.7z"
-}
-
-#if (Get-OSArchitectureWidth -Compare "32") { $arch = 'x86' } else { $arch = 'amd64'}
-
-foreach ($file in 'python.exe', 'pythonw.exe') {
-  New-Item -path $toolsDir\Launchy-3.1.2-win-${arch} -name "$file.ignore" -type File -force | Out-Null
 }
 
 Get-ChocolateyUnzip @packageArgs
@@ -19,6 +12,5 @@ Get-ChocolateyUnzip @packageArgs
 # Install start menu shortcut
 $programs = [environment]::GetFolderPath([environment+specialfolder]::Programs)
 $shortcutFilePath = Join-Path $programs "Launchy.lnk"
-#$targetPath = Join-Path $toolsDir "Launchy-3.1.2-win-${arch}\Launchy.exe"
-$targetPath = Join-Path $toolsDir "Launchy-3.1.2-win-x86\Launchy.exe"
+$targetPath = Join-Path $toolsDir "Launchy\Launchy.exe"
 Install-ChocolateyShortcut -shortcutFilePath $shortcutFilePath -targetPath $targetPath


### PR DESCRIPTION
The author stopped releasing a 64 bit version (after all, it never loads huge files, instead it launches other programs), so remove the commented-out 64-bit install script lines.

Remove references to python: these executable files seem to be no longer delivered as part of the package, instead it uses a DLL version.

Finally, change the shortcut's path to the Launchy executable: the software author changed the root folder in the 7z files, it now contains a "Launchy" root folder without version or architecture identifiers.

I have politely asked the author if from this point the simpler root name will remain the default, and got an answer that this is agreeable. Please see samsonwang/LaunchyQT#60.