### PR TITLE
Update chocolateyinstall.ps1

### DIFF
--- a/automatic/tjs.install/tools/chocolateyinstall.ps1
+++ b/automatic/tjs.install/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ $packageArgs = @{
   packageName    = $env:ChocolateyPackageName
 
   url64          = 'https://netcologne.dl.sourceforge.net/project/jasperstudio/JaspersoftStudio-6.18.1/TIB_js-studiocomm_6.18.1_windows_x86_64.exe'
-  checksum64     = '3327ca492684456cdcf3a27d1f9c7df9456cf31865e6589a6c1744f9b8ed6985'
+  checksum64     = '7b7777793a1ebd144c6df07d03d3a2bee6e38b02d4ecca28109bafec58de6921'
   checksumType64 = 'sha256'
 
   silentArgs     = "/S"


### PR DESCRIPTION
Fix error hashes do not match

Download of TIB_js-studiocomm_6.18.1_windows_x86_64.exe (404.42 MB) completed.
Error - hashes do not match. Actual value was '7b7777793a1ebd144c6df07d03d3a2bee6e38b02d4ecca28109bafec58de6921'.
ERROR: Checksum for 'C:\Users\*******\AppData\Local\Temp\chocolatey\tjs.install\6.18.1\TIB_js-studiocomm_6.18.1_windows_x86_64.exe' did not meet '3327ca492684456cdcf3a27d1f9c7df9456cf31865e6589a6c1744f9b8ed6985' for checksum type 'sha256'. Consider passing the actual checksums through with --checksum --checksum64 once you validate the checksums are appropriate. A less secure option is to pass --ignore-checksums if necessary.
The upgrade of tjs.install was NOT successful.
Error while running 'C:\ProgramData\chocolatey\lib\tjs.install\tools\chocolateyinstall.ps1'.
 See log for details.