### PR TITLE
Update hash for v3.42.0

### DIFF
--- a/automatic/lossless-cut/tools/chocolateyinstall.ps1
+++ b/automatic/lossless-cut/tools/chocolateyinstall.ps1
@@ -13,7 +13,7 @@ $packageArgs = @{
   packageName    = $env:ChocolateyPackageName
   unzipLocation  = "$installDir"
   url            = 'https://github.com/mifi/lossless-cut/releases/download/v3.42.0/LosslessCut-win.zip'
-  checksum       = '102c75d23ddc583e591d3927779448094f4e3f01b9cc47f245536e0f56c28089'
+  checksum       = 'EAF927E2CA368009964CF517A213FF4F036E4DD82BD3D44071125AD10408EC08'
   checksumType   = 'sha256'
 }
 Install-ChocolateyZipPackage @packageArgs


### PR DESCRIPTION
Fixes #56 

Some hours after the auto-update of the chocolatey installer, the maintainer of lossless-cut updated and rebuilt v3.42.0 to fix a breakage without changing the release tag.
mifi/lossless-cut@a380de7