### PR TITLE
Replace autohotkey.install deps with autohotkey.portable

### DIFF
--- a/automatic/acestream/acestream.nuspec
+++ b/automatic/acestream/acestream.nuspec
@@ -55,7 +55,7 @@ For further information:
 ]]></description>
     <releaseNotes>http://wiki.acestream.org/wiki/index.php/AceStream_3.0/en#Changelog</releaseNotes>
     <dependencies>
-     <dependency id="autohotkey.install" version="1.1.30" />
+     <dependency id="autohotkey.portable" version="1.1.30" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/atmel-studio/atmel-studio.nuspec
+++ b/automatic/atmel-studio/atmel-studio.nuspec
@@ -42,7 +42,7 @@
 ]]></description>
     <releaseNotes>https://www.microchip.com/mplab/avr-support/atmel-studio-7</releaseNotes>
     <dependencies>
-      <dependency id="autohotkey.install" version="1.1.30.03" />    
+      <dependency id="autohotkey.portable" version="1.1.30.03" />    
       <dependency id="kb2999226" version="1.0.20181019" />    
       <dependency id="sql2014.smo" version="12.0.2000.8" />
       <dependency id="netfx-4.5.1-devpack" version="4.5.50932" />

--- a/automatic/b1freearchiver/b1freearchiver.nuspec
+++ b/automatic/b1freearchiver/b1freearchiver.nuspec
@@ -57,7 +57,7 @@ With encryption you can protect data with 256 bit AES encryption algorithm. No o
     <packageSourceUrl>https://github.com/chtof/chocolatey-packages/tree/master/automatic/b1freearchiver</packageSourceUrl>
     <bugTrackerUrl>https://b1.org/support.jsp</bugTrackerUrl>
     <dependencies>
-      <dependency id="autohotkey.install" version="1.1.30.03" />
+      <dependency id="autohotkey.portable" version="1.1.30.03" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/buffalo-nas-navigator/buffalo-nas-navigator.nuspec
+++ b/automatic/buffalo-nas-navigator/buffalo-nas-navigator.nuspec
@@ -25,7 +25,7 @@
 ]]></description>
     <!-- <releaseNotes>__REPLACE_OR_REMOVE__MarkDown_Okay</releaseNotes> -->
     <dependencies>
-     <dependency id="autohotkey.install" version="1.1.30.03" />
+     <dependency id="autohotkey.portable" version="1.1.30.03" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/clipto.install/clipto.install.nuspec
+++ b/automatic/clipto.install/clipto.install.nuspec
@@ -41,7 +41,7 @@ See https://clipto.pro for details.
 ]]></description>
     <releaseNotes>https://github.com/clipto-pro/Desktop/releases</releaseNotes>
     <dependencies>
-      <dependency id="autohotkey.install" version="1.1.32" />
+      <dependency id="autohotkey.portable" version="1.1.32" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/elsie/elsie.nuspec
+++ b/automatic/elsie/elsie.nuspec
@@ -38,7 +38,7 @@ Elsie™ is an uncommon commercial-grade lumped-element ("L-C") electrical filte
 ]]></description>
   <releaseNotes>http://tonnesoftware.com/elsie.html</releaseNotes>
   <dependencies>
-    <dependency id="autohotkey.install" version="1.1.30.03" />
+    <dependency id="autohotkey.portable" version="1.1.30.03" />
   </dependencies>
   </metadata> 
   <files>

--- a/automatic/firestorm-opensim/firestorm-opensim.nuspec
+++ b/automatic/firestorm-opensim/firestorm-opensim.nuspec
@@ -27,7 +27,7 @@ The Phoenix Firestorm Project is currently active in developing the Firestorm Vi
 ]]></description>
     <releaseNotes>https://www.firestormviewer.org</releaseNotes>
     <dependencies>
-      <dependency id="autohotkey.install" version="1.1.33.06" />
+      <dependency id="autohotkey.portable" version="1.1.33.06" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/firestorm-secondlife/firestorm-secondlife.nuspec
+++ b/automatic/firestorm-secondlife/firestorm-secondlife.nuspec
@@ -27,7 +27,7 @@ The Phoenix Firestorm Project is currently active in developing the Firestorm Vi
 ]]></description>
     <releaseNotes>https://www.firestormviewer.org</releaseNotes>
     <dependencies>
-     <dependency id="autohotkey.install" version="1.1.33.06" />
+     <dependency id="autohotkey.portable" version="1.1.33.06" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/fontforge/fontforge.nuspec
+++ b/automatic/fontforge/fontforge.nuspec
@@ -39,7 +39,7 @@ FontForge can also extract fonts fom PDFs and validate fonts for potential issue
 ]]></description>
     <releaseNotes>https://github.com/fontforge/fontforge/releases</releaseNotes>
     <dependencies>
-      <dependency id="autohotkey.install" version="1.1.30.03" />
+      <dependency id="autohotkey.portable" version="1.1.30.03" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/gingerwriter/gingerwriter.nuspec
+++ b/automatic/gingerwriter/gingerwriter.nuspec
@@ -41,7 +41,7 @@ Ginger Writer runs only with Windows 10 version 1803 or greater.
 ]]></description>
     <!-- <releaseNotes>__REPLACE_OR_REMOVE__MarkDown_Okay</releaseNotes> -->
   <dependencies>
-    <dependency id="autohotkey.install" version="1.1.30.03" />
+    <dependency id="autohotkey.portable" version="1.1.30.03" />
   </dependencies>
   </metadata>
   <files>

--- a/automatic/gns3/gns3.nuspec
+++ b/automatic/gns3/gns3.nuspec
@@ -35,7 +35,7 @@ TIP: GNS3 does not only support Cisco devices. Cisco is often discussed because 
 ]]></description>
     <releaseNotes>https://docs.gns3.com/release.html</releaseNotes>
     <dependencies>
-      <dependency id="autohotkey.install" version="1.1.30" />
+      <dependency id="autohotkey.portable" version="1.1.30" />
       <dependency id="kb2999226" version="1.0.20181019" />
       <dependency id="vcredist140" version="14.16.27027.1" />
       <dependency id="winpcap" version="4.1.3.20161116" />

--- a/automatic/gopro-quik/gopro-quik.nuspec
+++ b/automatic/gopro-quik/gopro-quik.nuspec
@@ -38,7 +38,7 @@ Quik makes it easy to access, edit and enjoy your GoPro photos and videos. Autom
 ]]></description>
     <!-- <releaseNotes>__REPLACE_OR_REMOVE__MarkDown_Okay</releaseNotes> -->
     <dependencies>
-      <dependency id="autohotkey.install" version="1.1.31.01" />
+      <dependency id="autohotkey.portable" version="1.1.31.01" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/hashtools/hashtools.nuspec
+++ b/automatic/hashtools/hashtools.nuspec
@@ -32,7 +32,7 @@ Completely FreeHashTools is completely free, now and forever!
     <releaseNotes>https://www.binaryfortress.com/HashTools/ChangeLog/</releaseNotes>
     <dependencies>
       <dependency id="dotnetfx" version="4.6.2" />
-      <dependency id="autohotkey.install" version="1.1.30" />
+      <dependency id="autohotkey.portable" version="1.1.30" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/internet-download-manager/internet-download-manager.nuspec
+++ b/automatic/internet-download-manager/internet-download-manager.nuspec
@@ -58,7 +58,7 @@ To choose between the purchase options: [click here](https://secure.internetdown
 ]]></description>
     <releaseNotes>http://www.internetdownloadmanager.com/news.html</releaseNotes>
     <dependencies>
-      <dependency id="autohotkey.install" version="1.1.30.03" />
+      <dependency id="autohotkey.portable" version="1.1.30.03" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/jack/jack.nuspec
+++ b/automatic/jack/jack.nuspec
@@ -24,7 +24,7 @@
 ]]></description>
     <releaseNotes>https://github.com/jackaudio/jack2/releases</releaseNotes>
   <dependencies>
-    <dependency id="autohotkey.install" version="1.1.30.03" />
+    <dependency id="autohotkey.portable" version="1.1.30.03" />
   </dependencies>
   </metadata>
   <files>

--- a/automatic/locale-emulator/locale-emulator.nuspec
+++ b/automatic/locale-emulator/locale-emulator.nuspec
@@ -25,7 +25,7 @@
 ]]></description>
     <releaseNotes>https://github.com/xupefei/Locale-Emulator/releases</releaseNotes>
     <dependencies>
-      <dependency id="autohotkey.install" version="1.1.30" />
+      <dependency id="autohotkey.portable" version="1.1.30" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/natron.install/natron.install.nuspec
+++ b/automatic/natron.install/natron.install.nuspec
@@ -57,7 +57,7 @@ over 250 and ever increasing community plugins Here
 ]]></description>
   <releaseNotes>https://github.com/NatronGitHub/Natron/releases</releaseNotes>
   <dependencies>
-    <dependency id="autohotkey.install" version="1.1.30.03" />
+    <dependency id="autohotkey.portable" version="1.1.30.03" />
   </dependencies>
   </metadata>
   <files>

--- a/automatic/neatmouse/neatmouse.nuspec
+++ b/automatic/neatmouse/neatmouse.nuspec
@@ -48,7 +48,7 @@ By default, the mouse control keys for *NeatMouse* located on the keyboard numpa
 ]]></description>
     <releaseNotes>https://neatdecisions.com/products/neatmouse/history.php</releaseNotes>
     <dependencies>
-      <dependency id="autohotkey.install" version="1.1.30.03" />
+      <dependency id="autohotkey.portable" version="1.1.30.03" />
   </dependencies>
   </metadata>
   <files>

--- a/automatic/octave.install/octave.install.nuspec
+++ b/automatic/octave.install/octave.install.nuspec
@@ -38,7 +38,7 @@ Everyone is encouraged to share this software with others under the terms of the
 ]]></description>
     <releaseNotes>https://www.gnu.org/software/octave/news.html</releaseNotes>
     <dependencies>
-      <dependency id="autohotkey.install" version="1.1.30.03" />      
+      <dependency id="autohotkey.portable" version="1.1.30.03" />      
     </dependencies>    
   </metadata>
   <files>

--- a/automatic/simpleradiorecorder/simpleradiorecorder.nuspec
+++ b/automatic/simpleradiorecorder/simpleradiorecorder.nuspec
@@ -43,7 +43,7 @@ _** Minimum hardware installation may be required to begin recording of the soun
 ![screenshot](https://cdn.jsdelivr.net/gh/chtof/chocolatey-packages/automatic/simpleradiorecorder/screenshot.png)
 ]]></description>
     <dependencies>
-      <dependency id="autohotkey.install" version="1.1.30" />
+      <dependency id="autohotkey.portable" version="1.1.30" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/startup-organizer/startup-organizer.nuspec
+++ b/automatic/startup-organizer/startup-organizer.nuspec
@@ -44,7 +44,7 @@ You can also define the **order** in which to run your programs and even set a *
 ]]></description>
     <releaseNotes>https://metaproducts.com/news</releaseNotes>
     <dependencies>
-      <dependency id="autohotkey.install" version="1.1.30.03" />
+      <dependency id="autohotkey.portable" version="1.1.30.03" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/tapwindows/tapwindows.nuspec
+++ b/automatic/tapwindows/tapwindows.nuspec
@@ -24,7 +24,7 @@ NDIS 6.20 implementation of the TAP-Windows driver, used by OpenVPN and other ap
 ]]></description>
     <!-- <releaseNotes>__REPLACE_OR_REMOVE__MarkDown_Okay</releaseNotes> -->
     <dependencies>
-      <dependency id="autohotkey.install" version="1.1.30.01" />
+      <dependency id="autohotkey.portable" version="1.1.30.01" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/voicemeeter-banana.install/voicemeeter-banana.install.nuspec
+++ b/automatic/voicemeeter-banana.install/voicemeeter-banana.install.nuspec
@@ -34,7 +34,7 @@ For Volume licensing / special deals, especially for company deployment or comme
 ]]></description>
     <!-- <releaseNotes>__REPLACE_OR_REMOVE__MarkDown_Okay</releaseNotes> -->
   <dependencies>
-    <dependency id="autohotkey.install" version="1.1.30" />
+    <dependency id="autohotkey.portable" version="1.1.30" />
   </dependencies>
   </metadata>
   <files>

--- a/automatic/voicemeeter-potato.install/voicemeeter-potato.install.nuspec
+++ b/automatic/voicemeeter-potato.install/voicemeeter-potato.install.nuspec
@@ -32,7 +32,7 @@ For any professional use, you may pay the recommended license price on the websh
 ]]></description>
     <!-- <releaseNotes>__REPLACE_OR_REMOVE__MarkDown_Okay</releaseNotes> -->
   <dependencies>
-    <dependency id="autohotkey.install" version="1.1.30" />
+    <dependency id="autohotkey.portable" version="1.1.30" />
   </dependencies>
   </metadata>
   <files>

--- a/automatic/voicemeeter-potato.portable/voicemeeter-potato.portable.nuspec
+++ b/automatic/voicemeeter-potato.portable/voicemeeter-potato.portable.nuspec
@@ -32,7 +32,7 @@ For any professional use, you may pay the recommended license price on the websh
 ]]></description>
     <!-- <releaseNotes>__REPLACE_OR_REMOVE__MarkDown_Okay</releaseNotes> -->
   <dependencies>
-    <dependency id="autohotkey.install" version="1.1.30" />
+    <dependency id="autohotkey.portable" version="1.1.30" />
   </dependencies>
   </metadata>
   <files>

--- a/automatic/vuescan/vuescan.nuspec
+++ b/automatic/vuescan/vuescan.nuspec
@@ -102,7 +102,7 @@ Since 1998, VueScan has saved hundreds of thousands scanners from ending up in t
 ]]></description>
     <releaseNotes>https://www.hamrick.com/vuescan/vuescan.htm</releaseNotes>
     <dependencies>
-      <dependency id="autohotkey.install" version="1.1.30.03" />
+      <dependency id="autohotkey.portable" version="1.1.30.03" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/weasel/weasel.nuspec
+++ b/automatic/weasel/weasel.nuspec
@@ -24,7 +24,7 @@ Open source technology based on Zhongzhou rhyme input method engine/Rime Input M
 ]]></description>
     <releaseNotes>https://github.com/rime/weasel/releases</releaseNotes>
     <dependencies>
-     <dependency id="autohotkey.install" version="1.1.30.03" />
+     <dependency id="autohotkey.portable" version="1.1.30.03" />
     </dependencies>
   </metadata>
   <files>

--- a/manual/acronis-drive-monitor/acronis-drive-monitor.nuspec
+++ b/manual/acronis-drive-monitor/acronis-drive-monitor.nuspec
@@ -40,7 +40,7 @@ Sends an email and displays a message on the Windows taskbar when it uncovers a 
 ]]></description>
     <!-- <releaseNotes>__REPLACE_OR_REMOVE__MarkDown_Okay</releaseNotes> -->
     <dependencies>
-      <dependency id="autohotkey.install" version="1.1.30.03" />
+      <dependency id="autohotkey.portable" version="1.1.30.03" />
     </dependencies>
   </metadata>
   <files>

--- a/manual/battle.net/battle.net.nuspec
+++ b/manual/battle.net/battle.net.nuspec
@@ -64,7 +64,7 @@ Send and receive digital games and in-game items right from the Battle.net app.
 ]]></description>
     <!-- <releaseNotes>__REPLACE_OR_REMOVE__MarkDown_Okay</releaseNotes> -->
     <dependencies>
-      <dependency id="autohotkey.install" version="1.1.30.03" />
+      <dependency id="autohotkey.portable" version="1.1.30.03" />
     </dependencies>
   </metadata>
   <files>

--- a/manual/elsie/elsie.nuspec
+++ b/manual/elsie/elsie.nuspec
@@ -38,7 +38,7 @@ Elsie™ is an uncommon commercial-grade lumped-element ("L-C") electrical filte
 ]]></description>
   <releaseNotes>http://tonnesoftware.com/elsie.html</releaseNotes>
   <dependencies>
-    <dependency id="autohotkey.install" version="1.1.30.03" />
+    <dependency id="autohotkey.portable" version="1.1.30.03" />
   </dependencies>
   </metadata> 
   <files>

--- a/manual/imprimcheques/imprimcheques.nuspec
+++ b/manual/imprimcheques/imprimcheques.nuspec
@@ -29,7 +29,7 @@ See http://lalimacefolle.com/imprimcheques.php for all features (in french).
 ]]></description>
     <releaseNotes>http://lalimacefolle.com/Historique.TXT</releaseNotes>
     <dependencies>      
-      <dependency id="autohotkey.install" version="1.1.30" />
+      <dependency id="autohotkey.portable" version="1.1.30" />
     </dependencies>
   </metadata>
   <files>

--- a/manual/kmt/kmt.nuspec
+++ b/manual/kmt/kmt.nuspec
@@ -26,7 +26,7 @@ Koch's method of learning Morse is a simple, direct way of building reflexive re
 ]]></description>
     <releaseNotes>http://www.g4fon.net/CW%20Trainer.htm</releaseNotes>
     <dependencies>
-      <dependency id="autohotkey.install" version="1.1.32" />
+      <dependency id="autohotkey.portable" version="1.1.32" />
     </dependencies>
   </metadata>
   <files>

--- a/manual/little-fighter-2/little-fighter-2.nuspec
+++ b/manual/little-fighter-2/little-fighter-2.nuspec
@@ -46,7 +46,7 @@ There is also a small online game feature which enables you to connect and exper
 ]]></description>
     <!-- <releaseNotes>__REPLACE_OR_REMOVE__MarkDown_Okay</releaseNotes> -->
     <dependencies>
-      <dependency id="autohotkey.install" version="1.1.30.03" />
+      <dependency id="autohotkey.portable" version="1.1.30.03" />
       <dependency id="vcredist2005" version="8.1.0.20160118" />         
     </dependencies>
   </metadata>

--- a/manual/little-system-cleaner/little-system-cleaner.nuspec
+++ b/manual/little-system-cleaner/little-system-cleaner.nuspec
@@ -54,7 +54,7 @@ Little System Cleaner includes the following tools:
 ]]></description>
   <releaseNotes>https://www.little-apps.com/little-system-cleaner/history</releaseNotes>
   <dependencies>
-    <dependency id="autohotkey.install" version="1.1.30.03" />
+    <dependency id="autohotkey.portable" version="1.1.30.03" />
   </dependencies>
   </metadata>
   <files>

--- a/manual/pandafreeantivirus/pandafreeantivirus.nuspec
+++ b/manual/pandafreeantivirus/pandafreeantivirus.nuspec
@@ -38,7 +38,7 @@ And with no need to store files or perform daily updates!
 ]]></description>
     <!-- <releaseNotes>__REPLACE_OR_REMOVE__MarkDown_Okay</releaseNotes> -->
   <dependencies>
-    <dependency id="autohotkey.install" version="1.1.30.03" />
+    <dependency id="autohotkey.portable" version="1.1.30.03" />
     <dependency id="dotnetfx" version="4.7.2.20180712" />
   </dependencies>
   </metadata>

--- a/manual/pcw-fistcheck/pcw-fistcheck.nuspec
+++ b/manual/pcw-fistcheck/pcw-fistcheck.nuspec
@@ -29,7 +29,7 @@ The program will show you what you are keying, mark and space, dots and dashes. 
 ]]></description>
     <!-- <releaseNotes>__REPLACE_OR_REMOVE__MarkDown_Okay</releaseNotes> -->
     <dependencies>
-      <dependency id="autohotkey.install" version="1.1.32" />
+      <dependency id="autohotkey.portable" version="1.1.32" />
     </dependencies>
   </metadata>
   <files>

--- a/manual/pcw-tutor/pcw-tutor.nuspec
+++ b/manual/pcw-tutor/pcw-tutor.nuspec
@@ -27,7 +27,7 @@ You may use Precision CW Tutor as a Morse keyer, but it has not been specially d
 ]]></description>
     <!-- <releaseNotes>__REPLACE_OR_REMOVE__MarkDown_Okay</releaseNotes> -->
     <dependencies>
-      <dependency id="autohotkey.install" version="1.1.32" />
+      <dependency id="autohotkey.portable" version="1.1.32" />
     </dependencies>
   </metadata>
   <files>

--- a/manual/vb-cable/vb-cable.nuspec
+++ b/manual/vb-cable/vb-cable.nuspec
@@ -37,7 +37,7 @@ With VB-CABLE Technology, VB-Audio Applications can be endowed with Virtual I/O 
 ]]></description>
     <!-- <releaseNotes>__REPLACE_OR_REMOVE__MarkDown_Okay</releaseNotes> -->
     <dependencies>
-      <dependency id="autohotkey.install" version="1.1.30.03" />
+      <dependency id="autohotkey.portable" version="1.1.30.03" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
Did a simple search and replace. It is the norm to use `autohotkey.portable` instead of the `.install` package for ahk dependencies.


