### PR TITLE
Update and fix full auto install and uninstall of Battle.net chocolatey package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,3 @@ manual/klog/ReadMe.md
 *.exe
 *.vsix
 *.msi
-
-!Battle.net-Setup.exe

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ manual/klog/ReadMe.md
 *.exe
 *.vsix
 *.msi
+
+!Battle.net-Setup.exe

--- a/manual/battle.net/battle.net.nuspec
+++ b/manual/battle.net/battle.net.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>battle.net</id>
-    <version>1.18.0.3086</version>
+    <version>1.18.5.3106</version>
     <packageSourceUrl>https://github.com/chtof/chocolatey-packages/tree/master/manual/battle.net</packageSourceUrl>
     <owners>chtof</owners>
     <title>Blizzard Battle.net Desktop App</title>

--- a/manual/battle.net/battle.net.nuspec
+++ b/manual/battle.net/battle.net.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>battle.net</id>
-    <version>1.16.3.2988</version>
+    <version>1.18.0.3086</version>
     <packageSourceUrl>https://github.com/chtof/chocolatey-packages/tree/master/manual/battle.net</packageSourceUrl>
     <owners>chtof</owners>
     <title>Blizzard Battle.net Desktop App</title>

--- a/manual/battle.net/tools/chocolateyinstall.ahk
+++ b/manual/battle.net/tools/chocolateyinstall.ahk
@@ -23,7 +23,7 @@ If WinExist(winTitle1)
 ; Download Window
 ; Wait for the download to finish
 WinWait, %winTitle1%,, 15
-Sleep, 10000
+Sleep, 20000
 
 ; Choose install location
 ; C:\Program Files (x86)\Battle.net (Default)

--- a/manual/battle.net/tools/chocolateyinstall.ahk
+++ b/manual/battle.net/tools/chocolateyinstall.ahk
@@ -1,27 +1,39 @@
 #NoEnv
 #NoTrayIcon
-#Warn  ; Enable warnings to assist with detecting common errors.
-SendMode Input  ; Recommended for new scripts due to its superior speed and reliability.
-SetTitleMatchMode, 1  ; A windows's title must start with the specified WinTitle to be a match.
-SetControlDelay 0  
-SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
+#Warn ; Enable warnings to assist with detecting common errors.
+SendMode Input ; Recommended for new scripts due to its superior speed and reliability.
+SetTitleMatchMode, 1 ; A windows's title must start with the specified WinTitle to be a match.
+SetControlDelay 0 
+SetWorkingDir %A_ScriptDir% ; Ensures a consistent starting directory.
 
 ; Locale suppressed to be asked each time for language (enUS,frFR...)
 RegDelete, HKEY_CURRENT_USER\Software\Blizzard Entertainment\Launcher, Locale
 
-winTitle1 = ahk_class Blizzard Bootstrapper ahk_exe Battle.net-Setup.exe
+winTitle1 = ahk_class Blizzard Bootstrapper ahk_exe battle.netInstall.EXE
 ; Select a Language
 ; enGB zhCN zhTW deDE enSG esES esMX frFR itIT plPL ptBR ptPT ruRU
-WinWait, %winTitle1%,, 180
-ControlClick, x288 y84, %winTitle1% ; English
-Sleep 750
-ControlClick, x88 y296, %winTitle1% ; Continue
+WinWait, %winTitle1%,, 15
+If WinExist(winTitle1)
+{
+    ; English by default, unless otherwise stated
+    WinActivate
+    Send {Enter} ; Continue
+}
 
-;winTitle2 = ahk_class Qt5QWindowIcon ahk_exe Battle.net.exe
-loop {
-    ; Install Location
-    ControlClick, x633 y423, %winTitle1% ; Continue
-    Sleep 1000
+; Download Window
+; Wait for the download to finish
+WinWait, %winTitle1%,, 15
+Sleep, 10000
+
+; Choose install location
+; C:\Program Files (x86)\Battle.net (Default)
+; Also contains the option to stop Battle.net from starting on start up
+WinWait, %winTitle1%,, 15
+If WinExist(winTitle1)
+{
+    ; Proceed with defaults
+    WinActivate
+    Send {Enter} ; Continue
 }
 
 Exit

--- a/manual/battle.net/tools/chocolateyinstall.ps1
+++ b/manual/battle.net/tools/chocolateyinstall.ps1
@@ -1,9 +1,17 @@
 $ErrorActionPreference = 'Stop';
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$fileLocation = Join-Path $toolsDir 'Battle.net-Setup.exe'
 
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
-  url           = 'https://eu.battle.net/download/getInstaller?os=win&installer=Battle.net-Setup.exe'
+  unzipLocation = $toolsDir
+  fileType      = 'EXE'
+  file          = $fileLocation
+  softwareName  = 'Battle.net*'
+  checksum      = 'B32A976B66110524B7CC94C056E678617045D36DE80ABB5E798C2F91E91C5DA8'
+  checksumType  = 'sha256'
+  silentArgs    = ""
+  validExitCodes= @(0, 3010, 1641)
 }
 
 Start-Process "AutoHotKey" -Verb runas -ArgumentList "`"$toolsDir\chocolateyinstall.ahk`""
@@ -12,3 +20,6 @@ Install-ChocolateyPackage @packageArgs
 # Close AutoHotKey
 $autohotkey = Get-Process AutoHotKey -ErrorAction SilentlyContinue
 if ($autohotkey) { $autohotkey | Stop-Process }
+
+Start-Sleep -s 5
+Start-CheckandStop "Battle.net"

--- a/manual/battle.net/tools/chocolateyinstall.ps1
+++ b/manual/battle.net/tools/chocolateyinstall.ps1
@@ -1,6 +1,11 @@
 $ErrorActionPreference = 'Stop';
-$toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$toolsDir     = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$url          = 'https://us.battle.net/download/getInstaller?os=win&installer=Battle.net-Setup.exe&id=undefined'
 $fileLocation = Join-Path $toolsDir 'Battle.net-Setup.exe'
+$checksumType = 'sha256'
+
+Invoke-WebRequest $url -OutFile $fileLocation -UseBasicParsing
+$checksum = (Get-FileHash $fileLocation -Algorithm $checksumType).Hash
 
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
@@ -8,8 +13,8 @@ $packageArgs = @{
   fileType      = 'EXE'
   file          = $fileLocation
   softwareName  = 'Battle.net*'
-  checksum      = 'B32A976B66110524B7CC94C056E678617045D36DE80ABB5E798C2F91E91C5DA8'
-  checksumType  = 'sha256'
+  checksum      = $checksum
+  checksumType  = $checksumType
   silentArgs    = ""
   validExitCodes= @(0, 3010, 1641)
 }
@@ -21,5 +26,5 @@ Install-ChocolateyPackage @packageArgs
 $autohotkey = Get-Process AutoHotKey -ErrorAction SilentlyContinue
 if ($autohotkey) { $autohotkey | Stop-Process }
 
-Start-Sleep -s 5
+Start-Sleep -s 10
 Start-CheckandStop "Battle.net"

--- a/manual/battle.net/tools/chocolateyuninstall.ahk
+++ b/manual/battle.net/tools/chocolateyuninstall.ahk
@@ -1,11 +1,17 @@
 #NoEnv
 #NoTrayIcon
-#Warn  ; Enable warnings to assist with detecting common errors.
-SendMode Input  ; Recommended for new scripts due to its superior speed and reliability.
-SetTitleMatchMode, 1  ; A windows's title must start with the specified WinTitle to be a match.
-SetControlDelay 0  
-SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
+#Warn ; Enable warnings to assist with detecting common errors.
+SendMode Input ; Recommended for new scripts due to its superior speed and reliability.
+SetTitleMatchMode, 1 ; A windows's title must start with the specified WinTitle to be a match.
+SetControlDelay 0 
+SetWorkingDir %A_ScriptDir% ; Ensures a consistent starting directory.
 
+winTitle1 = ahk_class BlizzardUninstallWindowClass ahk_exe Blizzard Uninstaller.exe
 ; Uninstall Battle.net
-WinWait, ahk_class BlizzardUninstallWindowClass ahk_exe Blizzard Uninstaller.exe,, 60
-ControlClick, x100 y180, ahk_class BlizzardUninstallWindowClass ahk_exe Blizzard Uninstaller.exe
+WinWait, %winTitle1%,, 15
+If WinExist(winTitle1)
+{
+    WinActivate
+    Send {Tab} ; Switch from No, don't uninstall
+    Send {Enter} ; Yes, uninstall
+}

--- a/manual/battle.net/tools/chocolateyuninstall.ps1
+++ b/manual/battle.net/tools/chocolateyuninstall.ps1
@@ -1,6 +1,14 @@
 ﻿$ErrorActionPreference = 'Stop';
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
+$packageArgs = @{
+  packageName   = $env:ChocolateyPackageName
+  softwareName  = 'Battle.net*'
+  fileType      = 'EXE'
+  silentArgs    = '--lang=enUS --uid=battle.net --displayname="Battle.net"'
+  validExitCodes= @(0, 3010, 1605, 1614, 1641)
+  file          = 'C:\ProgramData\Battle.net\Agent\Blizzard Uninstaller.exe'
+}
+
 Start-Process "AutoHotKey" -Verb runas -ArgumentList "`"$toolsDir\chocolateyuninstall.ahk`""
-#Start-Process "C:\ProgramData\Battle.net\Agent\Blizzard Uninstaller.exe" -Wait -PassThru -Verb runas -ArgumentList "--lang=enUS --uid=battle.net --displayname=`"Battle.net`""
-& 'C:\ProgramData\Battle.net\Agent\Blizzard Uninstaller.exe' --lang=enUS --uid=battle.net --displayname=`"Battle.Net`"
+Uninstall-ChocolateyPackage @packageArgs


### PR DESCRIPTION
I changed the .gitignore to allow the Battle.net-Setup.exe to be committed because if we download the installer exe we obtain a different sha every time and I use these chocolatey packages with Ansible and it needs the shas to exist and match otherwise the task fails.

I also had to change the way that the uninstaller was being called so that it used the built in chocolatey function in order to get rid of chocolateys prompt about not being able to automatically detect automatic uninstallation.