### PR TITLE
Fix failing shortcut creation for minetest

### DIFF
--- a/automatic/minetest/tools/chocolateyinstall.ps1
+++ b/automatic/minetest/tools/chocolateyinstall.ps1
@@ -17,5 +17,5 @@ Remove-Item -Path $packageArgs.file,$packageArgs.file64
 # Install start menu shortcut
 $programs = [environment]::GetFolderPath([environment+specialfolder]::Programs)
 $shortcutFilePath = Join-Path $programs 'Minetest.lnk'
-$targetPath = Join-Path "$toolsLocation" "minetest-5.5.0-win$(Get-OSArchitectureWidth)\bin\minetest.exe"""
+$targetPath = Join-Path "$toolsLocation" "minetest-5.5.0-win$(Get-OSArchitectureWidth)\bin\minetest.exe"
 Install-ChocolateyShortcut -ShortcutFilePath $shortcutFilePath -TargetPath $targetPath


### PR DESCRIPTION
There were extra quotion marks, making Install-ChocolateyShortcut look for a filename with literal " at the end. This PR fixes that,