### PR TITLE
updating package to get checksum dynamically

### DIFF
--- a/automatic/helix-alm-client/ReadMe.md
+++ b/automatic/helix-alm-client/ReadMe.md
@@ -1,5 +1,5 @@
 ﻿# <img src="https://cdn.jsdelivr.net/gh/chtof/chocolatey-packages/automatic/helix-alm-client/helix-alm-client.png" width="48" height="48"/> [Helix ALM Desktop](https://chocolatey.org/packages/helix-alm-client)
 
-Dektop client for Helix ALM, application lifecycle management tool.
+Desktop client for Helix ALM, application lifecycle management tool.
 
 ![screenshot](https://cdn.jsdelivr.net/gh/chtof/chocolatey-packages/automatic/helix-alm-client/screenshot.png)

--- a/automatic/helix-alm-client/tools/chocolateyinstall.ps1
+++ b/automatic/helix-alm-client/tools/chocolateyinstall.ps1
@@ -1,13 +1,17 @@
 ﻿$ErrorActionPreference = 'Stop';
 
+$version = 'r2022.1.0'
+$baseurl = "https://cdist2.perforce.com/alm/helixalm/$version"
+$url = "$baseurl/ttwinclientinstall.exe"
+$checksum64 = ((Invoke-WebRequest "$baseurl/SHA256SUMS" -UseBasicParsing).RawContent.ToString().Split() | Select-String -Pattern 'ttwinclientinstall.exe' -SimpleMatch -Context 1,0 ).ToString().Trim().Split()[0]
+
 $packageArgs = @{
-  packageName  = $env:ChocolateyPackageName
-
-  url          = 'https://cdist2.perforce.com/alm/helixalm/r2022.1.0/ttwinclientinstall.exe'
-  checksum     = 'b5280432d1cc20087ecbaddbf41ab4afc323403885c9c686575e4622cd46ea2c'
-  checksumType = 'sha256'
-
-  silentArgs   = "-i SILENT LAX_VM resource\jre\bin\java.exe"
+  packageName    = $env:ChocolateyPackageName
+  installerType	 = 'EXE'
+  url            = $url
+  checksum       = $checksum64
+  checksumType   = 'sha256'
+  silentArgs	   = "-i SILENT LAX_VM resource\jre\bin\java.exe"
 }
 
 Install-ChocolateyPackage @packageArgs


### PR DESCRIPTION
The currently hardcoded value for `checksum` is outdated (correct value as of today is `24f8bef55aeea8d6f778381989dcfa4c7bc3b26a4a82afeeefe62cb5d1da10ff`) which causes package install to fail.  I have updated the logic to get the current checksum from this SHA256SUMS [file](https://cdist2.perforce.com/alm/helixalm/r2022.1.0/SHA256SUMS) hosted by Perforce. 