### PR TITLE
Fix new installer buttons

### DIFF
--- a/automatic/jack/tools/chocolateyinstall.ahk
+++ b/automatic/jack/tools/chocolateyinstall.ahk
@@ -11,28 +11,28 @@ winTitle = Setup - JACK2
 
 ; Installing Jack
 WinWait, %winTitle%, Welcome to the JACK, 120
-ControlClick, &Next >, %winTitle%
+ControlClick, &Next, %winTitle%
 
 ; Readme
 ;WinWait, %winTitle%, Readme, 10
-;ControlClick, &Next >, %winTitle%
+;ControlClick, &Next, %winTitle%
 
 ; License Agreement
 WinWait, %winTitle%, License Agreement, 10
 Sleep 500
 ;ControlClick, Button4, %winTitle% ; I &agree with the above terms and conditions
 ControlClick, TNewRadioButton1, %winTitle% ; I &agree with the above terms and conditions
-ControlClick, &Next >, %winTitle%
+ControlClick, &Next, %winTitle%
 
 ; Components
 WinWait, %winTitle%, Select Components, 10
 Sleep 500
-ControlClick, &Next >, %winTitle%
+ControlClick, &Next, %winTitle%
 
-; Select Start PMenu Folder
-WinWait, %winTitle%, Select Start PMenu Folder, 10
+; Select Start Menu Folder
+WinWait, %winTitle%, Select Start Menu Folder, 10
 Sleep 500
-ControlClick, &Next >, %winTitle%
+ControlClick, &Next, %winTitle%
 
 ; Ready to Install
 WinWait, %winTitle%, Ready to Install, 10


### PR DESCRIPTION
The Jack 1.9.21 installer is using buttons without a > sign. Hence the autokeyscript fails.
This PR is to update the button text used in the ahk script.