### PR TITLE
source-han-code-jp: Fix installation and uninstallation problems

### DIFF
--- a/automatic/source-han-code-jp/source-han-code-jp.nuspec
+++ b/automatic/source-han-code-jp/source-han-code-jp.nuspec
@@ -57,6 +57,9 @@ Source Han Code JP does not support any GPOS features.
 ![screenshot](https://cdn.jsdelivr.net/gh/chtof/chocolatey-packages/automatic/source-han-code-jp/screenshot.png)
 ]]></description>
     <releaseNotes>https://github.com/adobe-fonts/source-han-code-jp</releaseNotes>
+    <dependencies>
+      <dependency id="chocolatey-font-helpers.extension" version="0.0.4" />
+    </dependencies>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/automatic/source-han-code-jp/tools/chocolateyinstall.ps1
+++ b/automatic/source-han-code-jp/tools/chocolateyinstall.ps1
@@ -1,4 +1,6 @@
-﻿# The code structure for this from https://chocolatey.org/packages/hackfont
+﻿$ErrorActionPreference = 'Stop'
+
+# The code structure for this from https://chocolatey.org/packages/hackfont
  
 # create temp directory
 do {
@@ -17,14 +19,10 @@ $packageArgs = @{
  
 Install-ChocolateyZipPackage @packageArgs
  
-# Obtain system font folder for extraction
-$shell = New-Object -ComObject Shell.Application
-$fontsFolder = $shell.Namespace(0x14)
- 
 # Loop the extracted files and install them
-    Get-ChildItem -Path $tempPath\source-han-code-jp-$($env:ChocolateyPackageVersion)R\OTF -Recurse -Filter '*.otf' | ForEach-Object { 
+Get-ChildItem -Path $tempPath\source-han-code-jp-$($env:ChocolateyPackageVersion)R\OTF -Recurse -Filter '*.otf' | ForEach-Object { 
     Write-Verbose "Registering font '$($_.Name)'."
-    $fontsFolder.CopyHere($_.FullName)  # copying to fonts folder ignores a second param on CopyHere
+    Add-Font $_.FullName
 }
  
 # Remove our temporary files

--- a/automatic/source-han-code-jp/tools/chocolateyuninstall.ps1
+++ b/automatic/source-han-code-jp/tools/chocolateyuninstall.ps1
@@ -1,21 +1,13 @@
+$ErrorActionPreference = 'Stop'
+
 $packageArgs = @{
     packageName = $env:ChocolateyPackageName
     zipFileName = "$($env:ChocolateyPackageVersion).zip"    
 }
 Write-Verbose "Uninstall zip: $($packageArgs.zipFileName)"
 
-# different fonts path in the registry depending on os architecture
-$regPath = @( 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows NT\CurrentVersion\Fonts', 
-    'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts'
-)
+$fontFiles = (Get-ChildItem -Path "$([Environment]::GetFolderPath('Fonts'))" -Filter 'SourceHanCodeJP*.otf').Name
 
-# remove the fonts data from the registry path
-ForEach ($path in $regPath) {
-    (Get-Item -Path $path).property | Where-Object { $_ -like 'Source Han Code JP*' } | ForEach-Object { 
-        Remove-ItemProperty -Name $_ -Path $path -ErrorAction SilentlyContinue
-    }
-}
-
-Get-ChildItem -Path "$([Environment]::GetFolderPath('Fonts'))" -Filter 'Source Han Code JP*.otf' | Remove-Item -Force
+Remove-Font $fontFiles -Multiple
 
 Write-Warning 'If you receive any errors uninstalling, please reboot and try again to release the font files.'


### PR DESCRIPTION
Since Windows 10 build 1809, the shell variable 0x14 has been being
overloaded and redirected to the user's profile.

Thereby will place the file copied by `Shell.Application.Namespace(0x14).CopyHere()` into `C:\Users\<username>\AppData\Local\Microsoft\Windows\Fonts`.

The uninstall script was processing `$([Environment]::GetFolderPath('Fonts'))`, so there was a difference between the install directory and the uninstall directory.

To quickly solve this problem, the font-helper extension was added as a dependency, and the extension's function replaced adding and removing fonts.