### PR TITLE
sublimemerge: fix undefined variable

### DIFF
--- a/automatic/sublimemerge/tools/chocolateyinstall.ps1
+++ b/automatic/sublimemerge/tools/chocolateyinstall.ps1
@@ -1,5 +1,7 @@
 ﻿$ErrorActionPreference = 'Stop';
 
+$softwareName = 'Sublime Merge'
+
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
     


### PR DESCRIPTION
While implementing #83, a usage of `$softwareName` variable was added but the variable wasn't defined, this PR fixes it.

See the error from package validation for more information:
https://gist.github.com/choco-bot/a75eb347438792eb7f8875997872e9c7#file-install-txt-L465-L468 (found at https://community.chocolatey.org/packages/sublimemerge/0.0.2091)