### PR TITLE
Updated download url. The prior url was defunct

### DIFF
--- a/automatic/plantronicshub/tools/chocolateyinstall.ps1
+++ b/automatic/plantronicshub/tools/chocolateyinstall.ps1
@@ -3,7 +3,7 @@
 $packageArgs = @{
   packageName  = $env:ChocolateyPackageName
 
-  url          = 'https://www.poly.com/content/dam/www/software/PlantronicsHubInstaller.exe'
+  url          = 'https://downloads.poly.com/headsets/PlantronicsHubInstaller.exe'
   checksum     = 'e43484d770f3da729d8ba090604ad971a3db201ec7dfa80ad21cfe3cd3b38a52'
   checksumType = 'sha256'
 


### PR DESCRIPTION
https://downloads.poly.com/headsets/PlantronicsHubInstaller.exe is the updated and working download url.