### PR TITLE
(fontforge) Upgrade to support autohotkey v2

### DIFF
--- a/automatic/fontforge/fontforge.nuspec
+++ b/automatic/fontforge/fontforge.nuspec
@@ -39,7 +39,7 @@ FontForge can also extract fonts fom PDFs and validate fonts for potential issue
 ]]></description>
     <releaseNotes>https://github.com/fontforge/fontforge/releases</releaseNotes>
     <dependencies>
-      <dependency id="autohotkey.portable" version="1.1.30.03" />
+      <dependency id="autohotkey.portable" version="[2.0,)" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/fontforge/tools/chocolateyuninstall.ahk
+++ b/automatic/fontforge/tools/chocolateyuninstall.ahk
@@ -1,15 +1,14 @@
-#NoEnv
 #NoTrayIcon
-SendMode Input
-SetWorkingDir %A_ScriptDir%
-SetTitleMatchMode, 1   ;match if begins
-DetectHiddenText, off
-DetectHiddenWindows, off
- 
-winTitle = ahk_class #32770
- 
-WinWait, %winTitle%, Do you want to remove user preferences?, 120
-WinActivate
-Send,{Enter}
- 
-ExitApp
+SendMode("Input")
+SetWorkingDir(A_ScriptDir)
+SetTitleMatchMode(1)   ;match if begins
+DetectHiddenText(false)
+DetectHiddenWindows(false)
+
+winTitle := "ahk_class #32770"
+
+WinWait(winTitle, "Do you want to remove user preferences?", 120)
+WinActivate()
+Send("{Enter}")
+
+ExitApp()


### PR DESCRIPTION
Changes the uninstall ahk script to work with AHK version 2 and changes the dependency version.

On my system, it functioned properly, uninstalling the package correctly.