### PR TITLE
Install Path Machine Wide for Openssl

### DIFF
--- a/automatic/openssl/tools/chocolateyinstall.ps1
+++ b/automatic/openssl/tools/chocolateyinstall.ps1
@@ -16,7 +16,7 @@ $packageArgs = @{
 Install-ChocolateyPackage @packageArgs
 
 $path = Get-AppInstallLocation OpenSSL-Win
-Install-ChocolateyPath -PathToInstall "$path\bin"
+Install-ChocolateyPath -PathToInstall "$path\bin" -PathType Machine
 Install-ChocolateyEnvironmentVariable -VariableName OPENSSL_CONF -VariableValue "$path\bin\openssl.cfg"
 
 Write-Warning "OPENSSL_CONF has been set to $path\bin\openssl.cfg"


### PR DESCRIPTION
Install Path Machine Wide for Openssl. This fixes the issue where only the user is able to resolve OpenSSL instead of being resolvable across the system for all users and services.