### PR TITLE
ocenaudio/ocenaudio.install : update to v3.16.0

### DIFF
--- a/automatic/ocenaudio.install/ocenaudio.install.nuspec
+++ b/automatic/ocenaudio.install/ocenaudio.install.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ocenaudio.install</id>
-    <version>3.14.11</version>
+    <version>3.16.0</version>
     <packageSourceUrl>https://github.com/chtof/chocolatey-packages/tree/master/automatic/ocenaudio.install</packageSourceUrl>
     <owners>chtof</owners>
     <title>Ocenaudio (Install)</title>

--- a/automatic/ocenaudio.install/tools/chocolateyinstall.ps1
+++ b/automatic/ocenaudio.install/tools/chocolateyinstall.ps1
@@ -4,10 +4,9 @@ $packageArgs = @{
   packageName    = $env:ChocolateyPackageName
     
   url64          = 'https://www.ocenaudio.com/downloads/index.php/ocenaudio_windows64.exe'
-  checksum64     = '3a8d80a904b37103ec03d0226acfa75addc287201e02def009cd0c7f32b57586'
+  checksum64     = '2CB8837B784A1F09127BE38D66B6C30F6E083CD00C68FAC76EDB90867E22A52F'
   checksumType64 = 'sha256'
-
-  silentArgs     = "/S"
+  silentArgs     = "/allusers /S"
 }
 
 Install-ChocolateyPackage @packageArgs

--- a/automatic/ocenaudio.install/tools/chocolateyuninstall.ps1
+++ b/automatic/ocenaudio.install/tools/chocolateyuninstall.ps1
@@ -4,15 +4,16 @@ $packageArgs = @{
   packageName  = $env:ChocolateyPackageName
   softwareName = 'ocenaudio'
   fileType     = 'exe'
-  silentArgs   = "/S"
+  silentArgs   = "/AllUsers /S"
 }
 
-$uninstalled = $false
 [array]$key = Get-UninstallRegistryKey -SoftwareName $packageArgs['softwareName']
 
 if ($key.Count -eq 1) {
   $key | % {
-    $packageArgs['file'] = "$($_.UninstallString)"
+    $UninstallString = $key.UninstallString -split '"\s+'
+    $UninstallString[0] = $UninstallString[0] -replace '"',''
+    $packageArgs['file'] = "$($UninstallString[0])"
     Uninstall-ChocolateyPackage @packageArgs
   }
 } elseif ($key.Count -eq 0) {

--- a/automatic/ocenaudio/ocenaudio.nuspec
+++ b/automatic/ocenaudio/ocenaudio.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ocenaudio</id>
-    <version>3.14.11</version>
+    <version>3.16.0</version>
     <packageSourceUrl>https://github.com/chtof/chocolatey-packages/tree/master/automatic/ocenaudio</packageSourceUrl>
     <owners>chtof</owners>
     <title>Ocenaudio</title>
@@ -51,7 +51,7 @@ Advanced users will be surprised to find that the spectrogram settings are appli
 ![screenshot](https://cdn.jsdelivr.net/gh/chtof/chocolatey-packages/automatic/ocenaudio/screenshot.png)
 ]]></description>
   <dependencies>
-    <dependency id="ocenaudio.install" version="[3.14.11]" />
+    <dependency id="ocenaudio.install" version="[3.16.0]" />
   </dependencies>
   </metadata>
   <files></files>


### PR DESCRIPTION
### Updated packages "ocenaudio" and "ocenaudio.install" to version 3.16.0

- **Added "/allusers" option to the setup**, so that the program is installed in "C:\Program Files\ocenaudio" instead of user's appdata folder

- **Fixed uninstall script for "ocenaudio.install"**, some characters in UninstallString were not valid 