### PR TITLE
Update download location for offset-explorer

### DIFF
--- a/automatic/offset-explorer/offset-explorer.nuspec
+++ b/automatic/offset-explorer/offset-explorer.nuspec
@@ -3,14 +3,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>offset-explorer</id>
-    <version>4.0</version>
+    <version>4.0.1</version>
     <packageSourceUrl>https://github.com/chtof/chocolatey-packages/tree/master/automatic/offset-explorer</packageSourceUrl>
     <owners>chtof</owners>
     <title>Offset Explorer (Formerly Kafka Tool)</title>
     <authors>DB Solo LLC</authors>
     <projectUrl>http://www.kafkatool.com</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/chtof/chocolatey-packages/automatic/offset-explorer/offset-explorer.png</iconUrl>
-    <copyright>© 2015-2019 DB Solo, LLC. All rights reserved.</copyright>
+    <copyright>© 2015-2026 DB Solo, LLC. All rights reserved.</copyright>
     <licenseUrl>http://www.kafkatool.com/license.html</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <!--<projectSourceUrl>Software Source Location - is the software FOSS somewhere? Link to it with this</projectSourceUrl>-->

--- a/automatic/offset-explorer/tools/chocolateyinstall.ps1
+++ b/automatic/offset-explorer/tools/chocolateyinstall.ps1
@@ -1,17 +1,13 @@
 ﻿$ErrorActionPreference = 'Stop';
 
 $packageArgs = @{
-  packageName   = $env:ChocolateyPackageName
+  packageName    = $env:ChocolateyPackageName
 
-  url           = 'https://www.kafkatool.com/download3/offsetexplorer.exe'
-  checksum      = '120014bcaa5882bca5e8f3bbb4f0090e2523f662991af22d0676dfeae00786a6'
-  checksumType  = 'sha256'
+  url64bit       = 'https://www.kafkatool.com/download4/offsetexplorer_64bit.exe'
+  checksum64     = '6C20D9B2910A50A9401D10F69DE4D8C06B98EB4E9B6858CF273C9D98FF0C7896'
+  checksumType64 = 'sha256'
 
-  url64bit      = 'https://www.kafkatool.com/download3/offsetexplorer_64bit.exe'
-  checksum64    = '0128445b0b579792f78f761c45dd201e298d21cb0db6e2376b24ccccc3c6d251'
-  checksumType64= 'sha256'
-
-  silentArgs    = '-q'
+  silentArgs     = '-q'
 }
 
 Install-ChocolateyPackage @packageArgs

--- a/automatic/offset-explorer/update.ps1
+++ b/automatic/offset-explorer/update.ps1
@@ -8,14 +8,11 @@ function global:au_GetLatest {
     $download_page.RawContent -match $regex_version | Out-Null
     $version = $matches.Version
 
-    $regex32  = 'offsetexplorer.exe$'
-    $url32    = $download_page.links | ? href -match $regex32 | select -Last 1
     $regex64  = 'offsetexplorer_64bit.exe$'
     $url64    = $download_page.links | ? href -match $regex64 | select -Last 1
 
     return @{
         Version = $version
-        URL32   = 'http://www.kafkatool.com' + $url32.href
         URL64   = 'http://www.kafkatool.com' + $url64.href
      }
 }
@@ -23,7 +20,6 @@ function global:au_GetLatest {
 function global:au_SearchReplace {
     @{
         "tools\chocolateyInstall.ps1" = @{
-            "(^(\s)*checksum\s*=\s*)('.*')" = "`$1'$($Latest.Checksum32)'"
             "(^(\s)*checksum64\s*=\s*)('.*')" = "`$1'$($Latest.Checksum64)'"
         }
     }


### PR DESCRIPTION
Update download location for offset-explorer latest 4.0.1 version, 32 bit version is no longer available
Updated copyright statement as per website

Fixes #130 