### PR TITLE
poppler: publish poppler-windows binary releases above the published source-only versions

### DIFF
--- a/automatic/poppler/ReadMe.md
+++ b/automatic/poppler/ReadMe.md
@@ -1,3 +1,7 @@
 ﻿# [Poppler](https://chocolatey.org/packages/poppler)
 
 Poppler is a PDF rendering library based on the [xpdf-3.0](http://www.foolabs.com/xpdf) code base.
+
+This package installs the prebuilt, self-contained Windows binaries from [oschwartz10612/poppler-windows](https://github.com/oschwartz10612/poppler-windows) (conda-forge based build with all dependency DLLs included).
+
+Versioning: chocolatey.org already hosts source-only poppler packages up to 26.6.0, so binary releases are published as `26.6.0.<encoded binary version>` (see `update.ps1`) until poppler-windows versions overtake 26.6.0.

--- a/automatic/poppler/poppler.nuspec
+++ b/automatic/poppler/poppler.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>poppler</id>
-    <version>26.02.0</version>
+    <version>26.6.0.2602000</version>
     <packageSourceUrl>https://github.com/chtof/chocolatey-packages/tree/master/automatic/poppler</packageSourceUrl>
     <owners>chtof</owners>
     <title>Poppler</title>
@@ -20,8 +20,12 @@
     <tags>poppler PDF rendering library xpdf</tags>
     <summary>Poppler is a PDF rendering library based on the xpdf-3.0 code base.</summary>
     <description><![CDATA[Poppler is a PDF rendering library based on the [xpdf-3.0](http://www.foolabs.com/xpdf) code base.
+
+This package installs the prebuilt, self-contained Windows binaries (all dependency DLLs included) from [oschwartz10612/poppler-windows](https://github.com/oschwartz10612/poppler-windows).
+
+**Versioning note:** chocolatey.org already hosts source-only poppler packages up to 26.6.0, so binary releases are published as `26.6.0.<encoded binary version>` (this package contains poppler **26.02.0**, poppler-windows release v26.02.0-0) until poppler-windows versions overtake 26.6.0.
 ]]></description>
-    <releaseNotes>https://poppler.freedesktop.org/releases.html</releaseNotes>
+    <releaseNotes>https://github.com/oschwartz10612/poppler-windows/releases/tag/v26.02.0-0</releaseNotes>
   </metadata>
   <files>
     <file src="legal\**" target="legal" />

--- a/automatic/poppler/tools/chocolateyinstall.ps1
+++ b/automatic/poppler/tools/chocolateyinstall.ps1
@@ -9,3 +9,9 @@ $packageArgs = @{
 Get-ChocolateyUnzip @packageArgs
 
 Remove-Item $packageArgs.file64
+
+# The release zip bundles helper tools that are not part of Poppler (e.g. zstd.exe);
+# suppress their shims so they cannot collide with dedicated packages.
+Get-ChildItem $toolsDir -Recurse -Filter 'zstd.exe' | ForEach-Object {
+  New-Item "$($_.FullName).ignore" -ItemType File -Force | Out-Null
+}

--- a/automatic/poppler/update.ps1
+++ b/automatic/poppler/update.ps1
@@ -4,10 +4,33 @@
 function global:au_BeforeUpdate { Get-RemoteFiles -NoSuffix -Purge }
 
 function global:au_GetLatest {
-   return github_GetInfo -ArgumentList @{
+   $info = github_GetInfo -ArgumentList @{
         repository = 'oschwartz10612/poppler-windows'
         regex64    = '/Release-(?<Version>[\d\.-]+).zip'
    }
+
+   # Version mapping. chocolatey.org already hosts source-only poppler packages up to
+   # 26.6.0 (25.3.0 through 26.6.0 shipped the upstream source tarball instead of
+   # Windows binaries). A tag-derived version such as 26.02.0 normalizes to 26.2.0,
+   # which collides with the already-published source-only 26.2.0 (push rejected) and
+   # would sort below 26.6.0 anyway, so 'choco install poppler' would keep resolving
+   # the broken source-only package. Until poppler-windows overtakes 26.6.0, publish
+   # binary releases as 26.6.0.<encoded binary version> so they become the latest.
+   # Encoding: major*100000 + minor*1000 + patch*10 + build, e.g. v26.02.0-0 -> 2602000;
+   # successive binary releases keep sorting in the right order.
+   $m = [regex]::Match($info.URL64, 'Release-(?<base>[\d\.]+)-(?<build>\d+)\.zip')
+   $base    = [version]$m.Groups['base'].Value
+   $build   = [int]$m.Groups['build'].Value
+   $ceiling = [version]'26.6.0'
+   if ($base -le $ceiling) {
+       $encoded = $base.Major*100000 + $base.Minor*1000 + $base.Build*10 + $build
+       $info.Version = "$($ceiling).$($encoded)"
+   } elseif ($build -gt 0) {
+       $info.Version = "$($m.Groups['base'].Value).$($build)"
+   } else {
+       $info.Version = $m.Groups['base'].Value
+   }
+   return $info
 }
 
 function global:au_SearchReplace {


### PR DESCRIPTION
## Problem

`choco install poppler` currently delivers a package with no usable Windows binaries:

- **0.89.0** (2020) — last fully working version: embedded a self-contained win32 build.
- **22.11.0.x** — repacked a conda build without its dependency DLLs (`freetype.dll`, `zlib.dll`, `libpng16.dll`, `openjp2.dll`, `lcms2.dll`, `tiff.dll`, `libcurl.dll` are all absent from `Library/bin`), so `pdftocairo.exe`/`pdfinfo.exe` cannot start (verified via the DLL import table).
- **25.3.0 – 26.6.0** — contain only the upstream *source tarball* (`CMakeLists.txt`, `cpp/`, …), nothing to run.

Master already switched `update.ps1` to track [oschwartz10612/poppler-windows](https://github.com/oschwartz10612/poppler-windows) — the right approach, pioneered by @NightFurySL2001 in #123 for #122. But the fix cannot reach users: the tag-derived version `26.02.0` normalizes to `26.2.0`, which **collides with the already-published source-only 26.2.0** (the push is rejected), and would sort **below 26.6.0** anyway — so `choco install poppler` would still resolve the broken source-only package.

## Change

- **`update.ps1`** — keep tracking poppler-windows, but while the binary version is ≤ 26.6.0, publish as `26.6.0.<encoded binary version>` (`major*100000 + minor*1000 + patch*10 + build`, e.g. `v26.02.0-0` → `26.6.0.2602000`). This sorts above every published source-only version, never collides, keeps successive binary releases ordered, and returns to natural versioning automatically once poppler-windows overtakes 26.6.0 (edge cases verified, including a hypothetical `v26.6.0-0` → `26.6.0.2606000`).
- **`poppler.nuspec`** — version `26.6.0.2602000` for the current v26.02.0-0 release; description and releaseNotes document the binary provenance and the transitional version scheme.
- **`tools/chocolateyinstall.ps1`** — create `zstd.exe.ignore` after extraction so the helper binary bundled in the release zip is not shimmed (avoids a collision with a dedicated zstd package).
- **`ReadMe.md`** — note provenance and the version scheme.

## Testing (Windows 11)

- `choco pack` + `choco install poppler -s <local dir>` of this exact package: installs cleanly; ShimGen creates the 12 `pdf*` shims and **no** `zstd` shim.
- `pdftocairo -v` / `pdfinfo -v` → `26.02.0`; a real PDF → SVG conversion verified working.
- SHA256 of `Release-26.02.0-0.zip` independently verified and matches `legal/VERIFICATION.txt` (`993e4a94…cda5`).

## Complementary suggestion

Consider unlisting the source-only 25.3.0–26.6.0 and the DLL-less 22.11.0.x versions on chocolatey.org, so users who pin those versions stop receiving broken packages.

Closes #122. Builds on #123 (which this supersedes if merged). Related: #75.
